### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Build and publish Docker image
         if: github.ref == 'refs/heads/main'
-        uses: elgohr/Publish-Docker-Github-Action@33a481be3e179353cb7793a92b57cf9a6c985860 # v4
+        uses: elgohr/Publish-Docker-Github-Action@v5 # v4
         env:
           DYNAWO_VERSION: 1.4.0
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore