### PR TITLE
Use broad-castevent@main to fix errors on archived repos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Broadcast update event
         if: github.ref == 'refs/heads/main'
-        uses: gridsuite/broadcast-event@master
+        uses: gridsuite/broadcast-event@main
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           organizations: gridsuite


### PR DESCRIPTION
RequestError [HttpError]: Not Found
    at /home/runner/work/_actions/gridsuite/broadcast-event/master/dist/index.js:866:23
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  status: '404',

https://github.com/gridsuite/broadcast-event/commit/d413326f3f36a51dbec07958d377a8f6159458d5

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
Bug fix

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
error and scripts exits when broadcast on an archived repo


**What is the new behavior (if this is a feature change)?**
no error


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
